### PR TITLE
!fix: ensure server translations read route locale

### DIFF
--- a/app/[locale]/(default_layout)/page.tsx
+++ b/app/[locale]/(default_layout)/page.tsx
@@ -8,7 +8,7 @@ import Faq from "@/components/faq"
 
 export default async function Home({ params }: { params: { locale: string } }) {
 
-  const t = await getI18nServer()
+  const t = await getI18nServer(params.locale)
 
   return (
     <section className="grid justify-items-center gap-4 px-2 md:container">


### PR DESCRIPTION
## Summary
- pass the locale route parameter to `getI18nServer` when rendering the home page
- avoid errors when middleware has not yet set the locale cookies or headers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecbd6b883c832fb13b25413bce5aa7